### PR TITLE
Fixed wrong path

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ sudo pacman -S conky-manager
 ```
 2. Download Mainte theme from [Releases](https://github.com/gvoze32/Mainte/releases)
 
-3. Extract all folder and copy to /home/$USER/.conky (set hidden file to visible on your file manager cause the folder is hidden)
+3. Extract all folder and copy to `/home/$USER/.conky` (set hidden file to visible on your file manager cause the folder is hidden)
 
 4. Open terminal and type
 ```

--- a/README.md
+++ b/README.md
@@ -15,11 +15,11 @@ sudo pacman -S conky-manager
 ```
 2. Download Mainte theme from [Releases](https://github.com/gvoze32/Mainte/releases)
 
-3. Extract all folder and copy to ~/home/.conky (set hidden file to visible on your file manager cause the folder is hidden)
+3. Extract all folder and copy to /home/$USER/.conky (set hidden file to visible on your file manager cause the folder is hidden)
 
 4. Open terminal and type
 ```
-cd ~/home/.conky/Mainte
+cd /home/$USER/.conky/Mainte
 ./conky-launch.sh
 ```
 


### PR DESCRIPTION
Using `~/home/` as path will not work since most shells replace `'~'` by `'/home/$USER'`. So you end up with a path like `/home/$USER/home/`.